### PR TITLE
Use traits to simplify the arrow converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3276,6 +3276,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "assert_cmd",
+ "async-trait",
  "clap",
  "clio",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1.47.1", features = ["full"] }
 sanitize-filename = "0.6.0"
 serde_json = "1.0"
 serde = { version = "1.0.219", features = ["derive"] }
+async-trait = "0.1.89"
 
 [features]
 default = []


### PR DESCRIPTION
# WTF

I was having to use `match` conditionals with tons of duplicated code to handle both IPC stream and IPC file formats. This combines them using traits in order to simplify the code.
