### PR TITLE
Automatically run release action on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# WTF

Sets the release.yml action to automatically run on pushes to main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable the `Release` GitHub Actions workflow to run automatically on pushes to `main` (in addition to manual dispatch).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 021e6a60421987b149a5abe761441809bdedbbf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->