### PR TITLE
Switch to mimalloc from jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,6 +2716,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2792,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "minijinja"
@@ -3758,6 +3777,7 @@ dependencies = [
  "futures",
  "glob",
  "humansize",
+ "mimalloc",
  "minijinja",
  "num-format",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ datafusion = { version = "^52.2.0", features = [
 futures = "^0.3.32"
 glob = "^0.3.3"
 humansize = "^2.1.3"
+mimalloc = { version = "^0.1.48", features = ["v3"] }
 minijinja = "^2.17.1"
 num-format = "^0.4.4"
 owo-colors = "^4.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use clap::Parser;
+use mimalloc::MiMalloc;
 use silk_chiffon::{Cli, Commands, commands, default_thread_budget};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();


### PR DESCRIPTION
# WTF

Switch from jemalloc to mimalloc, datafusion works better with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the process-wide allocator can affect performance and memory behavior across the entire app, and may surface allocator-specific issues under load even though the code change is small.
> 
> **Overview**
> Switches the binary’s global allocator to `mimalloc` by adding the `mimalloc` dependency and wiring `MiMalloc` via `#[global_allocator]` in `src/main.rs`.
> 
> Updates `Cargo.lock` accordingly to pull in `mimalloc` and its `libmimalloc-sys` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c05d873177f2e2c8f7dcedab0587ecaa631e6f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->