### PR TITLE
New memory pool, reserved memory, new partitioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.parquet
 *.vortex
 /benchmark_output
+__pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apply_if"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84837f84ecd00f423b2ad69b019cefe631846930e00c3275daff8a5944223807"
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3763,6 +3778,7 @@ name = "silk_chiffon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "apply_if",
  "arrow",
  "assert_cmd",
  "async-stream",
@@ -3777,10 +3793,12 @@ dependencies = [
  "futures",
  "glob",
  "humansize",
+ "lru",
  "mimalloc",
  "minijinja",
  "num-format",
  "owo-colors",
+ "parking_lot",
  "parquet",
  "percent-encoding",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "^1.0.102"
+apply_if = "^1.2.1"
 bytesize = "^2.3.1"
 async-stream = "^0.3.6"
 async-trait = "^0.1.89"
@@ -31,10 +32,12 @@ datafusion = { version = "^52.2.0", features = [
 futures = "^0.3.32"
 glob = "^0.3.3"
 humansize = "^2.1.3"
+lru = "^0.16.3"
 mimalloc = { version = "^0.1.48", features = ["v3"] }
 minijinja = "^2.17.1"
 num-format = "^0.4.4"
 owo-colors = "^4.3.0"
+parking_lot = "^0.12.5"
 parquet = { version = "^57.3.0", features = [
   "default",
   "async",
@@ -45,6 +48,7 @@ percent-encoding = "^2.3.2"
 serde = { version = "^1.0.228", features = ["derive"] }
 serde_json = "^1.0.149"
 strum_macros = "^0.28.0"
+sysinfo = "0.38.3"
 tabled = { version = "^0.20.0", features = ["ansi"] }
 tempfile = "^3.26.0"
 tokio = { version = "^1.50.0", features = [
@@ -56,7 +60,6 @@ tokio = { version = "^1.50.0", features = [
 ] }
 uuid = { version = "^1.21.0", features = ["v4"] }
 vortex = { version = "^0.61.0", features = ["tokio", "files"] }
-sysinfo = "0.38.3"
 
 [features]
 default = []
@@ -65,7 +68,7 @@ default = []
 assert_cmd = "^2.1.2"
 criterion = { version = "^0.8.2", features = ["html_reports"] }
 predicates = "^3.1.4"
-rand = "0.10.0"
+rand = "^0.10.0"
 
 [[bench]]
 name = "parquet_writer"

--- a/justfile
+++ b/justfile
@@ -61,3 +61,5 @@ lint-fix-linux: _check-zigbuild
     cargo zigbuild clippy --target x86_64-unknown-linux-gnu --all-targets --all-features --fix --allow-dirty -- -D warnings
 
 alias lint := lint-fix
+
+verify: type-check fmt-fix lint-check

--- a/src/commands/transform.rs
+++ b/src/commands/transform.rs
@@ -1,10 +1,9 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use crate::{
-    AllColumnsBloomFilterConfig, ArrowCompression, ArrowIPCFormat, BloomFilterConfig,
-    ColumnDictionaryConfig, ColumnEncodingConfig, DEFAULT_BLOOM_FILTER_FPP, DataFormat,
-    DictionaryMode, ListOutputsFormat, ParquetCompression, ParquetEncoding, ParquetStatistics,
-    ParquetWriterVersion, PartitionStrategy, SortSpec, TransformCommand, default_thread_budget,
+    AllColumnsBloomFilterConfig, BloomFilterConfig, DEFAULT_BLOOM_FILTER_FPP, DataFormat,
+    ListOutputsFormat, PartitionStrategy, SortSpec, TransformCommand, default_thread_budget,
     io_strategies::{
         OutputFileInfo, input_strategy::InputStrategy, output_strategy::SinkFactory,
         path_template::PathTemplate,
@@ -24,6 +23,7 @@ use crate::{
     utils::memory::{estimate_sort_spill_reservation, sample_avg_row_bytes},
 };
 use anyhow::{Result, anyhow};
+use apply_if::ApplyIf;
 use arrow::datatypes::SchemaRef;
 use camino::Utf8Path;
 use glob::glob;
@@ -38,6 +38,7 @@ pub async fn run(args: TransformCommand) -> Result<()> {
         to_many,
         by,
         partition_strategy,
+        max_open_partitions,
         exclude_columns,
         list_outputs,
         list_outputs_file,
@@ -47,6 +48,8 @@ pub async fn run(args: TransformCommand) -> Result<()> {
         dialect,
         sort_by,
         memory_budget,
+        non_spillable_reserve,
+        memory_pool_top_consumers,
         preserve_input_order,
         target_partitions,
         input_format,
@@ -169,9 +172,20 @@ pub async fn run(args: TransformCommand) -> Result<()> {
         Some(total_budget * 20 / 100)
     };
 
+    if non_spillable_reserve.is_some() && effective_memory_limit.is_none() {
+        anyhow::bail!("--non-spillable-reserve requires a memory limit (--memory-budget)");
+    }
+
+    let effective_non_spillable_reserve = non_spillable_reserve
+        .zip(effective_memory_limit)
+        .map(|(spec, pool_size)| spec.resolve(pool_size))
+        .transpose()?;
+
     let mut pipeline = Pipeline::new()
         .with_query_dialect(dialect)
         .with_memory_limit(effective_memory_limit)
+        .with_non_spillable_reserve(effective_non_spillable_reserve)
+        .with_memory_pool_top_consumers(memory_pool_top_consumers)
         .with_target_partitions(effective_target_partitions)
         .with_spill_path(spill_path)
         .with_spill_compression(spill_compression);
@@ -287,11 +301,11 @@ pub async fn run(args: TransformCommand) -> Result<()> {
         vec![]
     };
 
-    // sort-single: requires global sort by partition columns (one file at a time)
-    // nosort-multi: keeps file handles open per partition, no sort required
+    // sort-single: global sort by partition columns, emits one partition file at a time
+    // nosort-multi/nosort-evict: file handles per partition, no sort needed
     let partition_sort_spec = match partition_strategy {
         PartitionStrategy::SortSingle => SortSpec::from(partition_columns.clone()),
-        PartitionStrategy::NosortMulti => SortSpec::default(),
+        PartitionStrategy::NosortMulti | PartitionStrategy::NosortEvict => SortSpec::default(),
     };
 
     let user_sort_spec = sort_by.clone().unwrap_or(SortSpec::default());
@@ -309,38 +323,66 @@ pub async fn run(args: TransformCommand) -> Result<()> {
     let mut full_sort_spec = partition_sort_spec.clone();
     full_sort_spec.extend(&user_sort_spec_without_partition_cols);
 
+    let arrow_opts = ArrowSinkOptions::new()
+        .with_compression(arrow_compression)
+        .with_format(arrow_format)
+        .with_record_batch_size(arrow_record_batch_size)
+        .with_queue_depth(arrow_writing_queue_size);
+
+    let parquet_opts = ParquetSinkOptions::new()
+        .with_parquet_compression(parquet_compression, parquet_compression_level)?
+        .with_statistics(parquet_statistics)
+        .with_writer_version(parquet_writer_version)
+        .with_ingestion_queue_size(parquet_ingestion_queue_size)
+        .with_encoding_queue_size(parquet_encoding_queue_size)
+        .with_writing_queue_size(parquet_writing_queue_size)
+        .with_no_dictionary(parquet_dictionary_all_off)
+        .with_dictionary_configs(&parquet_dictionary_column)
+        .with_column_no_dictionary(parquet_dictionary_column_off)
+        .with_encoding(parquet_encoding)
+        .with_column_encodings(parquet_column_encoding)
+        .with_bloom_filters(bloom_filter)
+        .with_offset_index_enabled(parquet_offset_index)
+        .with_skip_arrow_metadata(!parquet_arrow_metadata)
+        .with_page_header_statistics(parquet_page_header_statistics)
+        .apply_if_some(parquet_buffer_size, ParquetSinkOptions::with_buffer_size)
+        .apply_if_some(
+            parquet_row_group_size,
+            ParquetSinkOptions::with_max_row_group_size,
+        )
+        .apply_if_some(
+            parquet_row_group_concurrency,
+            ParquetSinkOptions::with_max_row_group_concurrency,
+        )
+        .apply_if_some(
+            parquet_data_page_size,
+            ParquetSinkOptions::with_data_page_size_limit,
+        )
+        .apply_if_some(
+            parquet_data_page_row_limit,
+            ParquetSinkOptions::with_data_page_row_count_limit,
+        )
+        .apply_if_some(
+            parquet_dictionary_page_size,
+            ParquetSinkOptions::with_dictionary_page_size_limit,
+        )
+        .apply_if_some(
+            parquet_write_batch_size,
+            ParquetSinkOptions::with_write_batch_size,
+        )
+        .apply_if_some(parquet_sort_spec, ParquetSinkOptions::with_sort_spec);
+
+    let vortex_opts = VortexSinkOptions::new().apply_if_some(
+        vortex_record_batch_size,
+        VortexSinkOptions::with_record_batch_size,
+    );
+
     let sink_factory = create_sink_factory(
         output_format,
-        arrow_compression,
-        arrow_format,
-        arrow_record_batch_size,
-        arrow_writing_queue_size,
-        bloom_filter,
-        parquet_buffer_size,
-        parquet_dictionary_column,
-        parquet_column_encoding,
-        parquet_dictionary_column_off,
-        parquet_compression,
-        parquet_compression_level,
-        parquet_ingestion_queue_size,
-        parquet_encoding_queue_size,
-        parquet_writing_queue_size,
-        parquet_encoding,
-        parquet_dictionary_all_off,
-        parquet_row_group_concurrency,
-        parquet_row_group_size,
-        parquet_sort_spec,
-        parquet_statistics,
-        parquet_writer_version,
-        parquet_data_page_size,
-        parquet_data_page_row_limit,
-        parquet_dictionary_page_size,
-        parquet_write_batch_size,
-        parquet_offset_index,
-        parquet_arrow_metadata,
-        parquet_page_header_statistics,
-        vortex_record_batch_size,
-        runtimes,
+        arrow_opts.clone(),
+        parquet_opts.clone(),
+        vortex_opts,
+        Arc::clone(&runtimes),
     )?;
 
     if let Some(output_path) = to {
@@ -354,26 +396,63 @@ pub async fn run(args: TransformCommand) -> Result<()> {
     } else if let Some(template) = to_many {
         let path_template = PathTemplate::new(template);
 
-        if partition_strategy == PartitionStrategy::NosortMulti {
-            pipeline = pipeline.with_multi_writer_partitioned_sink(
-                partition_columns,
-                path_template,
-                sink_factory,
-                exclude_columns.clone(),
-                create_dirs,
-                overwrite,
-                list_outputs.unwrap_or_default(),
+        if max_open_partitions.is_some() && partition_strategy != PartitionStrategy::NosortEvict {
+            anyhow::bail!(
+                "--max-open-partitions is only supported with --partition-strategy=nosort-evict"
             );
-        } else {
-            pipeline = pipeline.with_single_writer_partitioned_sink(
-                partition_columns,
-                path_template,
-                sink_factory,
-                exclude_columns.clone(),
-                create_dirs,
-                overwrite,
-                list_outputs.unwrap_or_default(),
-            );
+        }
+
+        let max_open_partitions = NonZeroUsize::new(max_open_partitions.unwrap_or(100))
+            .ok_or_else(|| anyhow!("--max-open-partitions must be at least 1"))?;
+
+        match partition_strategy {
+            PartitionStrategy::NosortMulti => {
+                pipeline = pipeline.with_multi_writer_partitioned_sink(
+                    partition_columns,
+                    path_template,
+                    sink_factory,
+                    exclude_columns.clone(),
+                    create_dirs,
+                    overwrite,
+                    list_outputs.unwrap_or_default(),
+                );
+            }
+            PartitionStrategy::NosortEvict => {
+                // each partition gets its own writer, so we minimize per-writer
+                // concurrency to avoid scheduling overhead from 100+ parallel pipelines
+                let evict_sink_factory = create_sink_factory(
+                    output_format,
+                    arrow_opts,
+                    parquet_opts
+                        .with_ingestion_queue_size(1)
+                        .with_encoding_queue_size(1)
+                        .with_writing_queue_size(1)
+                        .with_max_row_group_concurrency(1),
+                    vortex_opts,
+                    runtimes,
+                )?;
+                pipeline = pipeline.with_evict_writer_partitioned_sink(
+                    partition_columns,
+                    path_template,
+                    evict_sink_factory,
+                    exclude_columns.clone(),
+                    create_dirs,
+                    overwrite,
+                    list_outputs.unwrap_or_default(),
+                    max_open_partitions,
+                );
+            }
+            PartitionStrategy::SortSingle => {
+                pipeline = pipeline.with_single_writer_partitioned_sink(
+                    partition_columns,
+                    path_template,
+                    sink_factory,
+                    exclude_columns.clone(),
+                    create_dirs,
+                    overwrite,
+                    list_outputs.unwrap_or_default(),
+                );
+            }
         }
     }
 
@@ -526,38 +605,11 @@ fn detect_format(path: &str, explicit_format: Option<DataFormat>) -> Result<Data
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn create_sink_factory(
     output_format: Option<DataFormat>,
-    arrow_compression: ArrowCompression,
-    arrow_format: ArrowIPCFormat,
-    arrow_record_batch_size: usize,
-    arrow_writing_queue_size: usize,
-    parquet_bloom_filter: BloomFilterConfig,
-    parquet_buffer_size: Option<usize>,
-    parquet_dictionary_column: Vec<ColumnDictionaryConfig>,
-    parquet_column_encoding: Vec<ColumnEncodingConfig>,
-    parquet_dictionary_column_off: Vec<String>,
-    parquet_compression: ParquetCompression,
-    parquet_compression_level: Option<i32>,
-    parquet_ingestion_queue_size: usize,
-    parquet_encoding_queue_size: usize,
-    parquet_writing_queue_size: usize,
-    parquet_encoding: Option<ParquetEncoding>,
-    parquet_dictionary_all_off: bool,
-    parquet_row_group_concurrency: Option<usize>,
-    parquet_row_group_size: Option<usize>,
-    parquet_sort_spec: Option<SortSpec>,
-    parquet_statistics: ParquetStatistics,
-    parquet_writer_version: ParquetWriterVersion,
-    parquet_data_page_size: Option<usize>,
-    parquet_data_page_row_limit: Option<usize>,
-    parquet_dictionary_page_size: Option<usize>,
-    parquet_write_batch_size: Option<usize>,
-    parquet_offset_index: bool,
-    parquet_arrow_metadata: bool,
-    parquet_page_header_statistics: bool,
-    vortex_record_batch_size: Option<usize>,
+    arrow_opts: ArrowSinkOptions,
+    parquet_opts: ParquetSinkOptions,
+    vortex_opts: VortexSinkOptions,
     runtimes: Arc<ParquetRuntimes>,
 ) -> Result<SinkFactory> {
     Ok(Box::new(move |path: String, schema: SchemaRef| {
@@ -565,87 +617,15 @@ fn create_sink_factory(
 
         let sink: Box<dyn DataSink> = match detected_format {
             DataFormat::Arrow => {
-                let options = ArrowSinkOptions::new()
-                    .with_compression(arrow_compression)
-                    .with_format(arrow_format)
-                    .with_record_batch_size(arrow_record_batch_size)
-                    .with_queue_depth(arrow_writing_queue_size);
-                Box::new(ArrowSink::create(path.into(), &schema, options)?)
+                Box::new(ArrowSink::create(path.into(), &schema, arrow_opts.clone())?)
             }
-            DataFormat::Parquet => {
-                let compression = parquet_compression.to_compression(parquet_compression_level)?;
-                let mut options = ParquetSinkOptions::new()
-                    .with_compression(compression)
-                    .with_statistics(parquet_statistics)
-                    .with_writer_version(parquet_writer_version)
-                    .with_ingestion_queue_size(parquet_ingestion_queue_size)
-                    .with_encoding_queue_size(parquet_encoding_queue_size)
-                    .with_writing_queue_size(parquet_writing_queue_size);
-                if let Some(row_group_size) = parquet_row_group_size {
-                    options = options.with_max_row_group_size(row_group_size);
-                }
-                if let Some(buffer_size) = parquet_buffer_size {
-                    options = options.with_buffer_size(buffer_size);
-                }
-                if let Some(concurrency) = parquet_row_group_concurrency {
-                    options = options.with_max_row_group_concurrency(concurrency);
-                }
-                if parquet_dictionary_all_off {
-                    options = options.with_no_dictionary(true);
-                }
-
-                let mut column_dictionary_always = Vec::new();
-                let mut column_dictionary_analyze = Vec::new();
-                for config in &parquet_dictionary_column {
-                    match config.mode {
-                        DictionaryMode::Always => {
-                            column_dictionary_always.push(config.name.clone());
-                        }
-                        DictionaryMode::Analyze => {
-                            column_dictionary_analyze.push(config.name.clone());
-                        }
-                    }
-                }
-
-                options = options
-                    .with_column_dictionary_always(column_dictionary_always)
-                    .with_column_dictionary_analyze(column_dictionary_analyze)
-                    .with_column_no_dictionary(parquet_dictionary_column_off.clone())
-                    .with_encoding(parquet_encoding)
-                    .with_column_encodings(parquet_column_encoding.clone())
-                    .with_bloom_filters(parquet_bloom_filter.clone())
-                    .with_offset_index_enabled(parquet_offset_index)
-                    .with_skip_arrow_metadata(!parquet_arrow_metadata)
-                    .with_page_header_statistics(parquet_page_header_statistics);
-                if let Some(size) = parquet_data_page_size {
-                    options = options.with_data_page_size_limit(size);
-                }
-                if let Some(limit) = parquet_data_page_row_limit {
-                    options = options.with_data_page_row_count_limit(limit);
-                }
-                if let Some(size) = parquet_dictionary_page_size {
-                    options = options.with_dictionary_page_size_limit(size);
-                }
-                if let Some(size) = parquet_write_batch_size {
-                    options = options.with_write_batch_size(size);
-                }
-                if let Some(sort_spec) = parquet_sort_spec.clone() {
-                    options = options.with_sort_spec(sort_spec);
-                }
-                Box::new(ParquetSink::create(
-                    path.into(),
-                    &schema,
-                    &options,
-                    Arc::clone(&runtimes),
-                )?)
-            }
-            DataFormat::Vortex => {
-                let mut options = VortexSinkOptions::new();
-                if let Some(batch_size) = vortex_record_batch_size {
-                    options = options.with_record_batch_size(batch_size);
-                }
-                Box::new(VortexSink::create(path.into(), &schema, options)?)
-            }
+            DataFormat::Parquet => Box::new(ParquetSink::create(
+                path.into(),
+                &schema,
+                &parquet_opts,
+                Arc::clone(&runtimes),
+            )?),
+            DataFormat::Vortex => Box::new(VortexSink::create(path.into(), &schema, vortex_opts)?),
         };
 
         Ok(sink)

--- a/src/io_strategies/output_strategy.rs
+++ b/src/io_strategies/output_strategy.rs
@@ -1,10 +1,14 @@
 use std::{
     collections::{HashMap, hash_map::Entry},
+    num::NonZeroUsize,
     path::Path,
     sync::Arc,
 };
 
+use lru::LruCache;
+
 use anyhow::{Context, Result, anyhow};
+use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion::{execution::SendableRecordBatchStream, prelude::DataFrame};
 use futures::StreamExt;
@@ -117,6 +121,18 @@ pub enum OutputStrategy {
         create_dirs: bool,
         overwrite: bool,
         list_outputs: ListOutputsFormat,
+    },
+    /// Like PartitionedMultiWriter but caps open writers with LRU eviction.
+    /// Evicted partitions get new numbered files if they reappear.
+    PartitionedEvictWriter {
+        columns: Vec<String>,
+        template: Box<PathTemplate>,
+        sink_factory: SinkFactory,
+        exclude_columns: Vec<String>,
+        create_dirs: bool,
+        overwrite: bool,
+        list_outputs: ListOutputsFormat,
+        max_open: NonZeroUsize,
     },
 }
 
@@ -238,20 +254,7 @@ impl OutputStrategy {
                 overwrite,
                 list_outputs: _,
             } => {
-                let column_order = columns.clone();
-                let schema = stream.schema();
-
-                validate_partition_columns_primitive(&schema, columns)?;
-                validate_excluded_columns(&schema, exclude_columns)?;
-
-                let projected_column_indices =
-                    projection_indices_excluding(&schema, exclude_columns);
-
-                let projected_schema = match &projected_column_indices {
-                    Some(indices) => Arc::new(schema.project(indices)?),
-                    None => Arc::clone(&schema),
-                };
-
+                let ctx = PartitionedWriteContext::new(&stream.schema(), columns, exclude_columns)?;
                 let partitioner = Partitioner::new(columns.clone());
                 let mut partitioned_stream = partitioner.partition_stream(stream);
 
@@ -259,44 +262,133 @@ impl OutputStrategy {
 
                 while let Some(result) = partitioned_stream.next().await {
                     let (partition_values, batch) = result?;
-                    let key = partition_key(&partition_values, &column_order);
+                    let key = partition_key(&partition_values, &ctx.column_order);
 
                     let open_sink = match open_sinks.entry(key) {
                         Entry::Occupied(e) => e.into_mut(),
                         Entry::Vacant(e) => {
                             let path = template.resolve(&partition_values);
                             prepare_output_path(&path, *overwrite, *create_dirs).await?;
-                            let sink = sink_factory(path.clone(), Arc::clone(&projected_schema))?;
+                            let sink =
+                                sink_factory(path.clone(), Arc::clone(&ctx.projected_schema))?;
                             e.insert(OpenSink::new(sink, path, partition_values.clone()))
                         }
                     };
 
-                    let projected = match projected_column_indices {
-                        Some(ref indices) => batch.project(indices)?,
-                        None => batch,
-                    };
-
+                    let projected = ctx.project_batch(batch)?;
                     open_sink.sink.write_batch(projected).await?;
                 }
 
-                // finish all sinks and collect output info
-                let mut created_files = Vec::new();
-                for (_, mut open_sink) in open_sinks {
-                    let result = open_sink.sink.finish().await?;
-                    created_files.push(OutputFileInfo {
-                        path: open_sink.path,
-                        row_count: result.rows_written,
-                        partition_values: partition_values_to_json(
-                            &open_sink.partition_values,
-                            &column_order,
-                        ),
-                    });
+                drain_open_sinks(open_sinks, &ctx.column_order).await
+            }
+            OutputStrategy::PartitionedEvictWriter {
+                sink_factory,
+                columns,
+                exclude_columns,
+                template,
+                create_dirs,
+                overwrite,
+                list_outputs: _,
+                max_open,
+            } => {
+                let ctx = PartitionedWriteContext::new(&stream.schema(), columns, exclude_columns)?;
+                let partitioner = Partitioner::new(columns.clone());
+                let mut partitioned_stream = partitioner.partition_stream(stream);
+
+                let mut cache: LruCache<String, OpenSink> = LruCache::new(*max_open);
+                let mut file_counts: HashMap<String, usize> = HashMap::new();
+                let mut created_files: Vec<OutputFileInfo> = Vec::new();
+
+                while let Some(result) = partitioned_stream.next().await {
+                    let (partition_values, batch) = result?;
+                    let key = partition_key(&partition_values, &ctx.column_order);
+
+                    if cache.get(&key).is_none() {
+                        let file_idx = file_counts.entry(key.clone()).or_insert(0);
+                        let path = if *file_idx == 0 {
+                            template.resolve(&partition_values)
+                        } else {
+                            template.resolve_with_index(&partition_values, *file_idx)
+                        };
+                        *file_idx += 1;
+
+                        prepare_output_path(&path, *overwrite, *create_dirs).await?;
+                        let sink = sink_factory(path.clone(), Arc::clone(&ctx.projected_schema))?;
+                        let new_sink = OpenSink::new(sink, path, partition_values.clone());
+
+                        if let Some((_, mut evicted)) = cache.push(key.clone(), new_sink) {
+                            let result = evicted.sink.finish().await?;
+                            created_files.push(OutputFileInfo {
+                                path: evicted.path,
+                                row_count: result.rows_written,
+                                partition_values: partition_values_to_json(
+                                    &evicted.partition_values,
+                                    &ctx.column_order,
+                                ),
+                            });
+                        }
+                    }
+
+                    let open_sink = cache.get_mut(&key).unwrap();
+                    let projected = ctx.project_batch(batch)?;
+                    open_sink.sink.write_batch(projected).await?;
                 }
 
+                let mut remaining = drain_open_sinks(cache, &ctx.column_order).await?;
+                created_files.append(&mut remaining);
                 Ok(created_files)
             }
         }
     }
+}
+
+/// Shared setup for partitioned write strategies.
+struct PartitionedWriteContext {
+    column_order: Vec<String>,
+    projected_column_indices: Option<Vec<usize>>,
+    projected_schema: SchemaRef,
+}
+
+impl PartitionedWriteContext {
+    fn new(schema: &SchemaRef, columns: &[String], exclude_columns: &[String]) -> Result<Self> {
+        validate_partition_columns_primitive(schema, columns)?;
+        validate_excluded_columns(schema, exclude_columns)?;
+
+        let projected_column_indices = projection_indices_excluding(schema, exclude_columns);
+        let projected_schema = match &projected_column_indices {
+            Some(indices) => Arc::new(schema.project(indices)?),
+            None => Arc::clone(schema),
+        };
+
+        Ok(Self {
+            column_order: columns.to_vec(),
+            projected_column_indices,
+            projected_schema,
+        })
+    }
+
+    fn project_batch(&self, batch: RecordBatch) -> Result<RecordBatch> {
+        match self.projected_column_indices {
+            Some(ref indices) => Ok(batch.project(indices)?),
+            None => Ok(batch),
+        }
+    }
+}
+
+async fn drain_open_sinks(
+    sinks: impl IntoIterator<Item = (String, OpenSink)>,
+    column_order: &[String],
+) -> Result<Vec<OutputFileInfo>> {
+    let mut created_files = Vec::new();
+    for (_, mut open_sink) in sinks {
+        let result = open_sink.sink.finish().await?;
+        created_files.push(OutputFileInfo {
+            path: open_sink.path,
+            row_count: result.rows_written,
+            partition_values: partition_values_to_json(&open_sink.partition_values, column_order),
+        });
+    }
+    Ok(created_files)
 }
 
 #[cfg(test)]
@@ -1120,5 +1212,210 @@ mod tests {
                 rows_written: 0,
             })
         }
+    }
+
+    #[tokio::test]
+    async fn test_evict_under_cap() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+            ],
+        )
+        .unwrap();
+
+        let stream = create_test_stream(vec![batch]);
+        let sink_create_count = Arc::new(Mutex::new(0usize));
+        let sink_create_count_clone = Arc::clone(&sink_create_count);
+
+        let sink_factory: SinkFactory = Box::new(move |name, _schema| {
+            *sink_create_count_clone.lock().unwrap() += 1;
+            Ok(Box::new(MockSink {
+                name,
+                batches: Arc::new(Mutex::new(Vec::new())),
+                finished: Arc::new(Mutex::new(false)),
+            }))
+        });
+
+        let mut strategy = OutputStrategy::PartitionedEvictWriter {
+            columns: vec!["category".to_string()],
+            template: Box::new(PathTemplate::new("output/{{category}}.parquet".to_string())),
+            sink_factory,
+            exclude_columns: vec![],
+            create_dirs: false,
+            overwrite: false,
+            list_outputs: ListOutputsFormat::None,
+            max_open: NonZeroUsize::new(10).unwrap(),
+        };
+
+        let files = strategy.write_stream(stream).await.unwrap();
+        assert_eq!(*sink_create_count.lock().unwrap(), 3);
+        assert_eq!(files.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_evict_at_cap() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        // a, b, c -> when c arrives with max_open=2, one of a/b gets evicted
+        // then a again -> reopened with _1 suffix
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c", "a", "b"])),
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            ],
+        )
+        .unwrap();
+
+        let stream = create_test_stream(vec![batch]);
+        let created_paths = Arc::new(Mutex::new(Vec::new()));
+        let created_paths_clone = Arc::clone(&created_paths);
+
+        let sink_factory: SinkFactory = Box::new(move |name, _schema| {
+            created_paths_clone.lock().unwrap().push(name.clone());
+            Ok(Box::new(MockSink {
+                name,
+                batches: Arc::new(Mutex::new(Vec::new())),
+                finished: Arc::new(Mutex::new(false)),
+            }))
+        });
+
+        let mut strategy = OutputStrategy::PartitionedEvictWriter {
+            columns: vec!["category".to_string()],
+            template: Box::new(PathTemplate::new("output/{{category}}.parquet".to_string())),
+            sink_factory,
+            exclude_columns: vec![],
+            create_dirs: false,
+            overwrite: false,
+            list_outputs: ListOutputsFormat::None,
+            max_open: NonZeroUsize::new(2).unwrap(),
+        };
+
+        let files = strategy.write_stream(stream).await.unwrap();
+        let paths = created_paths.lock().unwrap();
+
+        // a, b, c (evicts a), a_1 (evicts b), b_1 (evicts c)
+        assert!(paths.contains(&"output/a.parquet".to_string()));
+        assert!(paths.contains(&"output/b.parquet".to_string()));
+        assert!(paths.contains(&"output/c.parquet".to_string()));
+        assert!(paths.contains(&"output/a_1.parquet".to_string()));
+        assert!(paths.contains(&"output/b_1.parquet".to_string()));
+        assert_eq!(paths.len(), 5);
+        assert_eq!(files.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_evict_file_numbering() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        // with max_open=1, every new partition evicts the previous
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "a", "b", "a"])),
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            ],
+        )
+        .unwrap();
+
+        let stream = create_test_stream(vec![batch]);
+        let created_paths = Arc::new(Mutex::new(Vec::new()));
+        let created_paths_clone = Arc::clone(&created_paths);
+
+        let sink_factory: SinkFactory = Box::new(move |name, _schema| {
+            created_paths_clone.lock().unwrap().push(name.clone());
+            Ok(Box::new(MockSink {
+                name,
+                batches: Arc::new(Mutex::new(Vec::new())),
+                finished: Arc::new(Mutex::new(false)),
+            }))
+        });
+
+        let mut strategy = OutputStrategy::PartitionedEvictWriter {
+            columns: vec!["category".to_string()],
+            template: Box::new(PathTemplate::new("output/{{category}}.parquet".to_string())),
+            sink_factory,
+            exclude_columns: vec![],
+            create_dirs: false,
+            overwrite: false,
+            list_outputs: ListOutputsFormat::None,
+            max_open: NonZeroUsize::new(1).unwrap(),
+        };
+
+        strategy.write_stream(stream).await.unwrap();
+        let paths = created_paths.lock().unwrap();
+
+        assert!(paths.contains(&"output/a.parquet".to_string()));
+        assert!(paths.contains(&"output/b.parquet".to_string()));
+        assert!(paths.contains(&"output/a_1.parquet".to_string()));
+        assert!(paths.contains(&"output/b_1.parquet".to_string()));
+        assert!(paths.contains(&"output/a_2.parquet".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_evict_lru_order() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        // write a, b, a, c -> with max_open=2, b should be evicted (not a)
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "a", "c"])),
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            ],
+        )
+        .unwrap();
+
+        let stream = create_test_stream(vec![batch]);
+        let finished_names = Arc::new(Mutex::new(Vec::new()));
+        let finished_names_clone = Arc::clone(&finished_names);
+
+        let sink_factory: SinkFactory = Box::new(move |name, _schema| {
+            let finished_names = Arc::clone(&finished_names_clone);
+            let name_for_finish = name.clone();
+            Ok(Box::new(MockSinkWithCallback {
+                name,
+                batches: Arc::new(Mutex::new(Vec::new())),
+                on_finish: Box::new(move || {
+                    finished_names.lock().unwrap().push(name_for_finish.clone());
+                }),
+            }))
+        });
+
+        let mut strategy = OutputStrategy::PartitionedEvictWriter {
+            columns: vec!["category".to_string()],
+            template: Box::new(PathTemplate::new("output/{{category}}.parquet".to_string())),
+            sink_factory,
+            exclude_columns: vec![],
+            create_dirs: false,
+            overwrite: false,
+            list_outputs: ListOutputsFormat::None,
+            max_open: NonZeroUsize::new(2).unwrap(),
+        };
+
+        strategy.write_stream(stream).await.unwrap();
+        let names = finished_names.lock().unwrap();
+
+        // b should be evicted first (LRU), then a and c finished at end
+        assert_eq!(
+            names[0], "output/b.parquet",
+            "b should be evicted first (LRU)"
+        );
     }
 }

--- a/src/io_strategies/path_template.rs
+++ b/src/io_strategies/path_template.rs
@@ -95,6 +95,21 @@ impl PathTemplate {
         let tmpl = self.env.template_from_str(&self.template_str).unwrap();
         tmpl.render(context).unwrap()
     }
+
+    /// Like resolve(), but inserts a file index before the extension.
+    /// e.g. "output/{{col}}.parquet" with index 2 -> "output/val_2.parquet"
+    pub fn resolve_with_index(&self, values: &PartitionValues, file_index: usize) -> String {
+        let base = self.resolve(values);
+        // find the dot only in the filename component, not directory parts
+        let filename_start = base.rfind('/').map_or(0, |i| i + 1);
+        match base[filename_start..].rfind('.') {
+            Some(dot_offset) => {
+                let dot_pos = filename_start + dot_offset;
+                format!("{}_{}{}", &base[..dot_pos], file_index, &base[dot_pos..])
+            }
+            None => format!("{}_{}", base, file_index),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -866,5 +881,71 @@ mod tests {
         let result = template.resolve(&values);
         // year and day escaped, month raw
         assert_eq!(result, "output/2024%2FQ1/01/15/15%3A30.parquet");
+    }
+
+    #[test]
+    fn test_resolve_with_index_standard() {
+        let template = PathTemplate::new("output/{{col}}.parquet".to_string());
+        let mut values = HashMap::new();
+        values.insert(
+            "col".to_string(),
+            Arc::new(StringArray::from(vec!["foo"])) as _,
+        );
+
+        assert_eq!(
+            template.resolve_with_index(&values, 0),
+            "output/foo_0.parquet"
+        );
+        assert_eq!(
+            template.resolve_with_index(&values, 3),
+            "output/foo_3.parquet"
+        );
+    }
+
+    #[test]
+    fn test_resolve_with_index_no_extension() {
+        let template = PathTemplate::new("output/{{col}}".to_string());
+        let mut values = HashMap::new();
+        values.insert(
+            "col".to_string(),
+            Arc::new(StringArray::from(vec!["bar"])) as _,
+        );
+
+        assert_eq!(template.resolve_with_index(&values, 1), "output/bar_1");
+    }
+
+    #[test]
+    fn test_resolve_with_index_nested_dirs() {
+        let template = PathTemplate::new("output/{{region}}/{{city}}.parquet".to_string());
+        let mut values = HashMap::new();
+        values.insert(
+            "region".to_string(),
+            Arc::new(StringArray::from(vec!["us"])) as _,
+        );
+        values.insert(
+            "city".to_string(),
+            Arc::new(StringArray::from(vec!["nyc"])) as _,
+        );
+
+        assert_eq!(
+            template.resolve_with_index(&values, 2),
+            "output/us/nyc_2.parquet"
+        );
+    }
+
+    #[test]
+    fn test_resolve_with_index_dotted_dir_no_extension() {
+        let template = PathTemplate::new("output/v2.0/{{col}}".to_string());
+        let mut values = HashMap::new();
+        values.insert(
+            "col".to_string(),
+            Arc::new(StringArray::from(vec!["data"])) as _,
+        );
+
+        // the dot is in the directory, not the filename -- index goes at the end
+        assert_eq!(
+            template.resolve_with_index(&values, 1),
+            "output/v2.0/data_1"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,77 @@ fn parse_percent(s: Option<&str>, default: u8) -> Result<u8> {
     Ok(pct)
 }
 
+/// Specifies a memory reserve as either a percentage or fixed byte size.
+///
+/// Used for pool sub-budgets where the reference point is the pool size.
+/// - `"10"` or `"10%"` - percentage of pool
+/// - `"200MB"` or `"1GiB"` - fixed byte size (unit required)
+#[derive(Debug, Clone, Copy)]
+pub enum PoolReserveSpec {
+    /// Percentage of pool size (1-99).
+    Percent(u8),
+    /// Fixed byte amount.
+    Fixed(usize),
+}
+
+impl PoolReserveSpec {
+    /// Resolve the reserve against the given pool size.
+    ///
+    /// Returns an error if pool_size is 0 or if the reserve exceeds `pool_size - 1`.
+    pub fn resolve(&self, pool_size: usize) -> Result<usize> {
+        if pool_size == 0 {
+            anyhow::bail!("cannot resolve non-spillable reserve against a zero-byte pool");
+        }
+
+        let reserve = match self {
+            Self::Percent(pct) => {
+                let r = pool_size * usize::from(*pct) / 100;
+                if r == 0 {
+                    anyhow::bail!(
+                        "non-spillable reserve of {pct}% resolves to 0 bytes for pool size {}; \
+                         use a larger pool or a fixed byte reserve instead",
+                        bytesize::ByteSize::b(pool_size as u64),
+                    );
+                }
+                r
+            }
+            Self::Fixed(n) => *n,
+        };
+
+        let max_reserve = pool_size - 1;
+        if reserve > max_reserve {
+            anyhow::bail!(
+                "non-spillable reserve ({}) exceeds pool size ({}); \
+                 the reserve must be less than the pool size",
+                bytesize::ByteSize::b(reserve as u64),
+                bytesize::ByteSize::b(pool_size as u64),
+            );
+        }
+
+        Ok(reserve)
+    }
+}
+
+impl FromStr for PoolReserveSpec {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s_stripped = s.strip_suffix('%').unwrap_or(s);
+
+        if !s_stripped.is_empty() && s_stripped.chars().all(|c| c.is_ascii_digit()) {
+            let pct: u8 = s_stripped
+                .parse()
+                .map_err(|_| anyhow!("invalid percentage '{s}': expected 1-99"))?;
+            if pct == 0 || pct >= 100 {
+                anyhow::bail!("reserve percentage must be between 1 and 99, got {pct}");
+            }
+            return Ok(Self::Percent(pct));
+        }
+
+        parse_nonzero_byte_size(s).map(Self::Fixed)
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(version = env!("SILK_CHIFFON_VERSION"), about, long_about = None)]
 pub struct Cli {
@@ -312,6 +383,13 @@ pub enum PartitionStrategy {
     /// No sorting required, preserves input order within each partition.
     /// Best for low-cardinality partition columns with low fragmentation.
     NosortMulti,
+    /// Like nosort-multi but caps the number of simultaneously open partition writers.
+    /// When the cap is hit, the least-recently-written partition is finalized.
+    /// If that partition reappears, a new numbered file is created.
+    /// Best for high-cardinality partitions where sorting is too expensive.
+    /// Per-writer concurrency is minimized (sequential encoding) since parallelism
+    /// comes from having many partition writers active simultaneously.
+    NosortEvict,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Display)]
@@ -1281,6 +1359,29 @@ pub struct TransformCommand {
     #[arg(long, help_heading = "Execution", value_parser = MemoryBudgetSpec::from_str, default_value = "total:80%")]
     pub memory_budget: MemoryBudgetSpec,
 
+    /// Reserve memory for non-spillable operations (sort merge phases, etc.).
+    ///
+    /// Enables an alternative memory pool that prevents spillable operators
+    /// (sorts, aggregations) from consuming the entire pool, guaranteeing
+    /// headroom for non-spillable consumers that would otherwise fail.
+    ///
+    /// Accepts a percentage (e.g. "10%", "10") or a fixed byte size (e.g. "200MB").
+    /// Percentages are resolved against the memory pool size.
+    ///
+    /// When not set, the default DataFusion FairSpillPool is used instead.
+    #[arg(long, help_heading = "Execution", value_parser = PoolReserveSpec::from_str)]
+    pub non_spillable_reserve: Option<PoolReserveSpec>,
+
+    /// Number of top memory consumers to report in out-of-memory error messages.
+    ///
+    /// When a memory allocation fails, the error message includes the N largest
+    /// memory consumers to help diagnose what is using the pool. Set to 0 to
+    /// report all consumers.
+    ///
+    /// Default: 10.
+    #[arg(long, help_heading = "Execution", default_value = "10")]
+    pub memory_pool_top_consumers: usize,
+
     /// Target thread budget for parallel work. Best-effort, not a hard limit.
     ///
     /// Accepts a number (e.g. "8"), "reserve:N" to use all CPUs minus N (minimum 1),
@@ -1351,6 +1452,12 @@ pub struct TransformCommand {
         help_heading = "Partitioning"
     )]
     pub partition_strategy: PartitionStrategy,
+
+    /// Maximum number of partition file handles to keep open simultaneously.
+    /// When this limit is reached, the least-recently-written partition is finalized.
+    /// Only used with --partition-strategy=nosort-evict. Defaults to 100.
+    #[arg(long, requires = "by", help_heading = "Partitioning")]
+    pub max_open_partitions: Option<usize>,
 
     /// List the output files after creation (only with --to-many).
     #[arg(
@@ -1824,11 +1931,14 @@ impl TransformCommand {
             query: None,
             sort_by: None,
             memory_budget: MemoryBudgetSpec::Total { pct: 80, min: None },
+            non_spillable_reserve: None,
+            memory_pool_top_consumers: 10,
             preserve_input_order: false,
             target_partitions: None,
             thread_budget: None,
             by: None,
             partition_strategy: PartitionStrategy::default(),
+            max_open_partitions: None,
             list_outputs: None,
             list_outputs_file: None,
             create_dirs: true,
@@ -2108,6 +2218,83 @@ mod tests {
             assert!(ThreadBudgetSpec::from_str("reserve").is_err());
             assert!(ThreadBudgetSpec::from_str("garbage:2").is_err());
             assert!(ThreadBudgetSpec::from_str("reserve:abc").is_err());
+        }
+    }
+
+    mod pool_reserve_spec_tests {
+        use super::*;
+
+        #[test]
+        fn parse_bare_number_as_percentage() {
+            let spec: PoolReserveSpec = "10".parse().unwrap();
+            assert!(matches!(spec, PoolReserveSpec::Percent(10)));
+        }
+
+        #[test]
+        fn parse_percentage_with_suffix() {
+            let spec: PoolReserveSpec = "25%".parse().unwrap();
+            assert!(matches!(spec, PoolReserveSpec::Percent(25)));
+        }
+
+        #[test]
+        fn parse_fixed_byte_size() {
+            let spec: PoolReserveSpec = "200MB".parse().unwrap();
+            assert!(matches!(spec, PoolReserveSpec::Fixed(200_000_000)));
+        }
+
+        #[test]
+        fn parse_fixed_byte_size_binary() {
+            let spec: PoolReserveSpec = "1GiB".parse().unwrap();
+            assert!(matches!(spec, PoolReserveSpec::Fixed(1_073_741_824)));
+        }
+
+        #[test]
+        fn reject_zero_percentage() {
+            assert!("0".parse::<PoolReserveSpec>().is_err());
+            assert!("0%".parse::<PoolReserveSpec>().is_err());
+        }
+
+        #[test]
+        fn reject_100_percent() {
+            assert!("100".parse::<PoolReserveSpec>().is_err());
+            assert!("100%".parse::<PoolReserveSpec>().is_err());
+        }
+
+        #[test]
+        fn reject_empty_string() {
+            assert!("".parse::<PoolReserveSpec>().is_err());
+        }
+
+        #[test]
+        fn resolve_percentage() {
+            let spec = PoolReserveSpec::Percent(10);
+            assert_eq!(spec.resolve(1000).unwrap(), 100);
+        }
+
+        #[test]
+        fn resolve_fixed_errors_when_exceeds_pool() {
+            let spec = PoolReserveSpec::Fixed(8_000_000_000);
+            let err = spec.resolve(4_000_000_000).unwrap_err();
+            assert!(err.to_string().contains("exceeds pool size"));
+        }
+
+        #[test]
+        fn resolve_fixed_within_pool() {
+            let spec = PoolReserveSpec::Fixed(200_000_000);
+            assert_eq!(spec.resolve(1_000_000_000).unwrap(), 200_000_000);
+        }
+
+        #[test]
+        fn resolve_percentage_errors_when_rounds_to_zero() {
+            let spec = PoolReserveSpec::Percent(1);
+            let err = spec.resolve(50).unwrap_err();
+            assert!(err.to_string().contains("resolves to 0 bytes"));
+        }
+
+        #[test]
+        fn resolve_errors_on_zero_pool() {
+            let spec = PoolReserveSpec::Percent(10);
+            assert!(spec.resolve(0).is_err());
         }
     }
 

--- a/src/pipeline/memory_pool.rs
+++ b/src/pipeline/memory_pool.rs
@@ -16,17 +16,17 @@ use parking_lot::Mutex;
 /// Memory is partitioned into two regions:
 ///
 /// ```text
-/// ┌──────────────────────────────────────────────────────────────┐
-/// │                        pool_size                             │
-/// │                                                              │
-/// │  ┌─────────────────────────────┐  ┌────────────────────────┐ │
-/// │  │   spillable region          │  │  non-spillable reserve │ │
-/// │  │   (pool_size - reserve)     │  │  (reserve_for_         │ │
-/// │  │                             │  │   non_spillable)       │ │
-/// │  │  spillable consumers share  │  │                        │ │
-/// │  │  this region evenly         │  │  non-spillable only    │ │
-/// │  └─────────────────────────────┘  └────────────────────────┘ │
-/// └──────────────────────────────────────────────────────────────┘
+/// ┌─────────────────────────────────────────────────────────────────────┐
+/// │                        pool_size                                    │
+/// │                                                                     │
+/// │  ┌─────────────────────────────┐  ┌───────────────────────────────┐ │
+/// │  │   spillable region          │  │  non-spillable reserve        │ │
+/// │  │   (pool_size - reserve)     │  │  (reserve_for_non_spillable)  │ │
+/// │  │                             │  │                               │ │
+/// │  │  spillable consumers share  │  │                               │ │
+/// │  │  this region evenly         │  │  non-spillable only           │ │
+/// │  └─────────────────────────────┘  └───────────────────────────────┘ │
+/// └─────────────────────────────────────────────────────────────────────┘
 /// ```
 ///
 /// - **Spillable consumers** can only use `pool_size - reserve_for_non_spillable`,

--- a/src/pipeline/memory_pool.rs
+++ b/src/pipeline/memory_pool.rs
@@ -1,0 +1,340 @@
+//! A memory pool that reserves capacity for non-spillable consumers.
+//!
+//! DataFusion's built-in `FairSpillPool` divides memory evenly among spillable consumers,
+//! but when spillable consumers have already consumed most of the pool, non-spillable
+//! consumers (like sort merge phases) can fail to allocate even small amounts. This pool
+//! solves that by maintaining a reserve that only non-spillable consumers can use.
+
+use datafusion::common::{Result, resources_datafusion_err};
+use datafusion::execution::memory_pool::{
+    MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation, human_readable_size,
+};
+use parking_lot::Mutex;
+
+/// A [`MemoryPool`] that guarantees a portion of capacity for non-spillable consumers.
+///
+/// Memory is partitioned into two regions:
+///
+/// ```text
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │                        pool_size                             │
+/// │                                                              │
+/// │  ┌─────────────────────────────┐  ┌────────────────────────┐ │
+/// │  │   spillable region          │  │  non-spillable reserve │ │
+/// │  │   (pool_size - reserve)     │  │  (reserve_for_         │ │
+/// │  │                             │  │   non_spillable)       │ │
+/// │  │  spillable consumers share  │  │                        │ │
+/// │  │  this region evenly         │  │  non-spillable only    │ │
+/// │  └─────────────────────────────┘  └────────────────────────┘ │
+/// └──────────────────────────────────────────────────────────────┘
+/// ```
+///
+/// - **Spillable consumers** can only use `pool_size - reserve_for_non_spillable`,
+///   divided evenly among all registered spillable consumers (like `FairSpillPool`).
+/// - **Non-spillable consumers** can use the entire pool (spillable region + reserve),
+///   allocated first-come first-served.
+#[derive(Debug)]
+pub struct ReservedSpillPool {
+    pool_size: usize,
+    /// memory that spillable consumers cannot touch
+    reserve_for_non_spillable: usize,
+    state: Mutex<PoolState>,
+}
+
+#[derive(Debug)]
+struct PoolState {
+    num_spill: usize,
+    spillable: usize,
+    non_spillable: usize,
+}
+
+impl ReservedSpillPool {
+    /// Create a new pool with `pool_size` total bytes and `reserve_for_non_spillable` bytes
+    /// reserved exclusively for non-spillable consumers.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `pool_size` is 0 or `reserve_for_non_spillable >= pool_size`.
+    pub fn new(pool_size: usize, reserve_for_non_spillable: usize) -> Self {
+        assert!(pool_size > 0, "pool size must be greater than 0");
+        assert!(
+            reserve_for_non_spillable < pool_size,
+            "non-spillable reserve ({}) must be less than pool size ({})",
+            human_readable_size(reserve_for_non_spillable),
+            human_readable_size(pool_size),
+        );
+        Self {
+            pool_size,
+            reserve_for_non_spillable,
+            state: Mutex::new(PoolState {
+                num_spill: 0,
+                spillable: 0,
+                non_spillable: 0,
+            }),
+        }
+    }
+}
+
+impl MemoryPool for ReservedSpillPool {
+    fn register(&self, consumer: &MemoryConsumer) {
+        if consumer.can_spill() {
+            self.state.lock().num_spill += 1;
+        }
+    }
+
+    fn unregister(&self, consumer: &MemoryConsumer) {
+        if consumer.can_spill() {
+            let mut state = self.state.lock();
+            state.num_spill = state.num_spill.checked_sub(1).unwrap();
+        }
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        let mut state = self.state.lock();
+        match reservation.consumer().can_spill() {
+            true => state.spillable += additional,
+            false => state.non_spillable += additional,
+        }
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        let mut state = self.state.lock();
+        match reservation.consumer().can_spill() {
+            true => {
+                state.spillable = state
+                    .spillable
+                    .checked_sub(shrink)
+                    .expect("spillable underflow: shrink exceeds tracked spillable usage");
+            }
+            false => {
+                state.non_spillable = state
+                    .non_spillable
+                    .checked_sub(shrink)
+                    .expect("non-spillable underflow: shrink exceeds tracked non-spillable usage");
+            }
+        }
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
+        let mut state = self.state.lock();
+
+        match reservation.consumer().can_spill() {
+            true => {
+                // spillable consumers share the spillable region evenly,
+                // dynamically reduced when non-spillable usage exceeds the reserve
+                let spill_capacity = self
+                    .pool_size
+                    .saturating_sub(state.non_spillable.max(self.reserve_for_non_spillable));
+                let per_consumer = spill_capacity
+                    .checked_div(state.num_spill)
+                    .unwrap_or(spill_capacity);
+
+                if reservation.size() + additional > per_consumer {
+                    return Err(resources_datafusion_err!(
+                        "Failed to allocate additional {} for {} with {} already allocated \
+                         for this reservation - {} remain available for this consumer's \
+                         fair share ({} per consumer, {} spillable capacity)",
+                        human_readable_size(additional),
+                        reservation.consumer().name(),
+                        human_readable_size(reservation.size()),
+                        human_readable_size(per_consumer.saturating_sub(reservation.size())),
+                        human_readable_size(per_consumer),
+                        human_readable_size(spill_capacity)
+                    ));
+                }
+                state.spillable += additional;
+            }
+            false => {
+                // non-spillable consumers can use the full pool
+                let available = self
+                    .pool_size
+                    .saturating_sub(state.non_spillable + state.spillable);
+
+                if available < additional {
+                    return Err(resources_datafusion_err!(
+                        "Failed to allocate additional {} for {} with {} already allocated \
+                         for this reservation - {} remain available for the total pool",
+                        human_readable_size(additional),
+                        reservation.consumer().name(),
+                        human_readable_size(reservation.size()),
+                        human_readable_size(available)
+                    ));
+                }
+                state.non_spillable += additional;
+            }
+        }
+        Ok(())
+    }
+
+    fn reserved(&self) -> usize {
+        let state = self.state.lock();
+        state.spillable + state.non_spillable
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        MemoryLimit::Finite(self.pool_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn non_spillable_can_use_reserve() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("spiller")
+            .with_can_spill(true)
+            .register(&pool);
+        s1.try_grow(80).unwrap();
+
+        let mut ns1 = MemoryConsumer::new("merger").register(&pool);
+        ns1.try_grow(20).unwrap();
+
+        assert_eq!(pool.reserved(), 100);
+    }
+
+    #[test]
+    fn spillable_cannot_use_reserve() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("spiller")
+            .with_can_spill(true)
+            .register(&pool);
+
+        s1.try_grow(80).unwrap();
+
+        let err = s1.try_grow(1).unwrap_err().strip_backtrace();
+        assert!(err.contains("Failed to allocate"), "{err}");
+    }
+
+    #[test]
+    fn fair_sharing_among_spillable() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("s1")
+            .with_can_spill(true)
+            .register(&pool);
+        let mut s2 = MemoryConsumer::new("s2")
+            .with_can_spill(true)
+            .register(&pool);
+
+        // each spillable consumer gets 80/2 = 40
+        s1.try_grow(40).unwrap();
+        s2.try_grow(40).unwrap();
+
+        let err = s1.try_grow(1).unwrap_err().strip_backtrace();
+        assert!(err.contains("Failed to allocate"), "{err}");
+    }
+
+    #[test]
+    fn non_spillable_uses_freed_spillable_memory() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("spiller")
+            .with_can_spill(true)
+            .register(&pool);
+        s1.try_grow(60).unwrap();
+
+        // non-spillable can use reserve + whatever spillable hasn't claimed
+        let mut ns1 = MemoryConsumer::new("merger").register(&pool);
+        ns1.try_grow(40).unwrap(); // 100 - 60 = 40 available
+
+        assert_eq!(pool.reserved(), 100);
+    }
+
+    #[test]
+    fn grow_and_shrink_tracking() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("spiller")
+            .with_can_spill(true)
+            .register(&pool);
+        s1.grow(50);
+        assert_eq!(pool.reserved(), 50);
+
+        s1.shrink(30);
+        assert_eq!(pool.reserved(), 20);
+
+        let mut ns1 = MemoryConsumer::new("merger").register(&pool);
+        ns1.grow(10);
+        assert_eq!(pool.reserved(), 30);
+
+        ns1.shrink(5);
+        assert_eq!(pool.reserved(), 25);
+    }
+
+    #[test]
+    fn spillable_share_adjusts_on_drop() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("s1")
+            .with_can_spill(true)
+            .register(&pool);
+        let s2 = MemoryConsumer::new("s2")
+            .with_can_spill(true)
+            .register(&pool);
+
+        // 2 spillable consumers: each gets 40
+        s1.try_grow(40).unwrap();
+        let err = s1.try_grow(1).unwrap_err().strip_backtrace();
+        assert!(err.contains("Failed to allocate"), "{err}");
+
+        // drop s2, now s1 gets the full 80
+        drop(s2);
+        s1.try_grow(40).unwrap();
+        assert_eq!(s1.size(), 80);
+    }
+
+    #[test]
+    fn non_spillable_denied_when_pool_full() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        let mut s1 = MemoryConsumer::new("spiller")
+            .with_can_spill(true)
+            .register(&pool);
+        s1.try_grow(80).unwrap();
+
+        let mut ns1 = MemoryConsumer::new("merger").register(&pool);
+        ns1.try_grow(20).unwrap();
+
+        // pool is full (100/100), second non-spillable allocation fails
+        let mut ns2 = MemoryConsumer::new("merger2").register(&pool);
+        let err = ns2.try_grow(1).unwrap_err().strip_backtrace();
+        assert!(err.contains("Failed to allocate"), "{err}");
+    }
+
+    #[test]
+    fn spillable_adjusts_when_non_spillable_exceeds_reserve() {
+        let pool = Arc::new(ReservedSpillPool::new(100, 20)) as Arc<dyn MemoryPool>;
+
+        // non-spillable uses 40 (more than the 20 reserve)
+        let mut ns1 = MemoryConsumer::new("merger").register(&pool);
+        ns1.try_grow(40).unwrap();
+
+        // spillable should only get (100 - 40) / 1 = 60, not (100 - 20) / 1 = 80
+        let mut s1 = MemoryConsumer::new("spiller")
+            .with_can_spill(true)
+            .register(&pool);
+        s1.try_grow(60).unwrap();
+
+        let err = s1.try_grow(1).unwrap_err().strip_backtrace();
+        assert!(err.contains("Failed to allocate"), "{err}");
+
+        assert_eq!(pool.reserved(), 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-spillable reserve")]
+    fn panics_on_invalid_reserve() {
+        ReservedSpillPool::new(100, 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "pool size must be greater than 0")]
+    fn panics_on_zero_pool_size() {
+        ReservedSpillPool::new(0, 0);
+    }
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,13 +1,18 @@
-use crate::utils::memory::total_memory;
+mod memory_pool;
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
 use anyhow::{Result, anyhow};
 use bytesize::ByteSize;
 use camino::Utf8PathBuf;
-use datafusion::{
-    execution::memory_pool::FairSpillPool,
-    prelude::{SessionConfig, SessionContext},
-};
+use datafusion::execution::memory_pool::{FairSpillPool, MemoryPool, TrackConsumersPool};
+use datafusion::prelude::{SessionConfig, SessionContext};
 use tempfile::TempDir;
 
+use memory_pool::ReservedSpillPool;
+
+use crate::utils::memory::total_memory;
 use crate::{
     ListOutputsFormat, QueryDialect, SpillCompression,
     io_strategies::{
@@ -19,7 +24,6 @@ use crate::{
     operations::data_operation::DataOperation,
 };
 
-#[derive(Default)]
 pub struct PipelineConfig {
     pub working_directory: Option<String>,
     pub query_dialect: QueryDialect,
@@ -28,6 +32,24 @@ pub struct PipelineConfig {
     pub spill_path: Option<Utf8PathBuf>,
     pub spill_compression: SpillCompression,
     pub sort_spill_reservation_bytes: Option<usize>,
+    pub non_spillable_reserve: Option<usize>,
+    pub memory_pool_top_consumers: usize,
+}
+
+impl Default for PipelineConfig {
+    fn default() -> Self {
+        Self {
+            working_directory: None,
+            query_dialect: QueryDialect::default(),
+            memory_limit: None,
+            target_partitions: None,
+            spill_path: None,
+            spill_compression: SpillCompression::default(),
+            sort_spill_reservation_bytes: None,
+            non_spillable_reserve: None,
+            memory_pool_top_consumers: 10,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -123,6 +145,32 @@ impl Pipeline {
         self
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_evict_writer_partitioned_sink(
+        mut self,
+        columns: Vec<String>,
+        template: PathTemplate,
+        sink_factory: SinkFactory,
+        exclude_columns: Vec<String>,
+        create_dirs: bool,
+        overwrite: bool,
+        list_outputs: ListOutputsFormat,
+        max_open: NonZeroUsize,
+    ) -> Self {
+        self.output_strategy = Some(OutputStrategy::PartitionedEvictWriter {
+            columns,
+            template: Box::new(template),
+            sink_factory,
+            exclude_columns,
+            create_dirs,
+            overwrite,
+            list_outputs,
+            max_open,
+        });
+
+        self
+    }
+
     pub fn with_working_directory(mut self, working_directory: String) -> Self {
         self.config.working_directory = Some(working_directory);
         self
@@ -158,6 +206,16 @@ impl Pipeline {
         sort_spill_reservation_bytes: Option<usize>,
     ) -> Self {
         self.config.sort_spill_reservation_bytes = sort_spill_reservation_bytes;
+        self
+    }
+
+    pub fn with_non_spillable_reserve(mut self, reserve: Option<usize>) -> Self {
+        self.config.non_spillable_reserve = reserve;
+        self
+    }
+
+    pub fn with_memory_pool_top_consumers(mut self, n: usize) -> Self {
+        self.config.memory_pool_top_consumers = n;
         self
     }
 
@@ -237,10 +295,25 @@ impl Pipeline {
             path.try_into()?
         };
 
-        let pool = FairSpillPool::new(memory_limit);
+        let top_n = match self.config.memory_pool_top_consumers {
+            0 => NonZeroUsize::MAX,
+            n => NonZeroUsize::new(n).expect("nonzero by match"),
+        };
+
+        let pool: Arc<dyn MemoryPool> = match self.config.non_spillable_reserve {
+            Some(reserve) => {
+                let inner = ReservedSpillPool::new(memory_limit, reserve);
+                Arc::new(TrackConsumersPool::new(inner, top_n))
+            }
+            None => {
+                let inner = FairSpillPool::new(memory_limit);
+                Arc::new(TrackConsumersPool::new(inner, top_n))
+            }
+        };
+
         let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::default()
             .with_temp_file_path(&spill_path)
-            .with_memory_pool(std::sync::Arc::new(pool))
+            .with_memory_pool(pool)
             .build()?;
 
         Ok(SessionContext::new_with_config_rt(

--- a/src/sinks/arrow.rs
+++ b/src/sinks/arrow.rs
@@ -19,6 +19,7 @@ use crate::{
     utils::memory::estimate_row_bytes,
 };
 
+#[derive(Clone)]
 pub struct ArrowSinkOptions {
     format: ArrowIPCFormat,
     record_batch_size: usize,

--- a/src/sinks/parquet/adaptive_writer/analysis.rs
+++ b/src/sinks/parquet/adaptive_writer/analysis.rs
@@ -11,7 +11,7 @@ use arrow::array::{Array, AsArray, RecordBatch};
 use arrow::datatypes::{DataType, SchemaRef};
 use datafusion::functions::string::expr_fn::octet_length;
 use datafusion::functions_aggregate::expr_fn::{approx_distinct, avg, count_distinct};
-use datafusion::prelude::{SessionConfig, SessionContext, cast, col};
+use datafusion::prelude::{SessionConfig, SessionContext, col};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
@@ -91,13 +91,18 @@ async fn run_streaming_analysis(
 
     let mut agg_exprs = Vec::new();
     for col_name in &columns {
+        // approx_distinct uses HyperLogLog and returns UInt64 but only supports
+        // a subset of types. count_distinct supports all types but returns Int64.
+        // we handle both return types in extract_analysis_from_results because
+        // DataFusion's cast(count_distinct(...), UInt64) breaks with certain column
+        // types (e.g. Boolean) where the count_distinct implementation doesn't
+        // support the cast expression.
         let ndv_expr = if let Ok(field) = schema.field_with_name(col_name)
             && supports_approx_distinct(field.data_type())
         {
             approx_distinct(col(col_name))
         } else {
-            // count_distinct returns Int64, cast to UInt64 for consistency
-            cast(count_distinct(col(col_name)), DataType::UInt64)
+            count_distinct(col(col_name))
         };
         agg_exprs.push(ndv_expr.alias(format!("{col_name}_ndv")));
 
@@ -169,8 +174,15 @@ fn extract_analysis_from_results(
 
         let approx_distinct = batch
             .column_by_name(&ndv_col)
-            .and_then(|arr| arr.as_primitive_opt::<arrow::datatypes::UInt64Type>())
-            .and_then(|arr| arr.is_valid(0).then(|| arr.value(0)))
+            .and_then(|arr| {
+                // approx_distinct returns UInt64, count_distinct returns Int64
+                arr.as_primitive_opt::<arrow::datatypes::UInt64Type>()
+                    .and_then(|a| a.is_valid(0).then(|| a.value(0)))
+                    .or_else(|| {
+                        arr.as_primitive_opt::<arrow::datatypes::Int64Type>()
+                            .and_then(|a| a.is_valid(0).then(|| a.value(0).max(0).cast_unsigned()))
+                    })
+            })
             .unwrap_or(0);
 
         let avg_value_size = batch

--- a/src/sinks/parquet/mod.rs
+++ b/src/sinks/parquet/mod.rs
@@ -32,8 +32,9 @@ use arrow::{
 use async_trait::async_trait;
 
 use crate::{
-    BloomFilterConfig, ColumnEncodingConfig, ParquetEncoding, ParquetStatistics,
-    ParquetWriterVersion, SortDirection, SortSpec,
+    BloomFilterConfig, ColumnDictionaryConfig, ColumnEncodingConfig, DictionaryMode,
+    ParquetCompression, ParquetEncoding, ParquetStatistics, ParquetWriterVersion, SortDirection,
+    SortSpec,
     sinks::data_sink::{DataSink, SinkResult},
     utils::memory::estimate_row_bytes,
 };
@@ -42,6 +43,7 @@ use crate::{
 ///
 /// Column paths use dot notation with prefix matching. For example, "user" matches
 /// all columns under the user struct (user.name, user.address.city, etc.).
+#[derive(Clone)]
 pub struct ParquetSinkOptions {
     /// Rows per row group.
     pub max_row_group_size: usize,
@@ -164,6 +166,16 @@ impl ParquetSinkOptions {
         self
     }
 
+    /// Resolve a `ParquetCompression` enum + optional level into the low-level
+    /// `Compression` type and set it on this options struct.
+    pub fn with_parquet_compression(
+        self,
+        compression: ParquetCompression,
+        level: Option<i32>,
+    ) -> anyhow::Result<Self> {
+        Ok(self.with_compression(compression.to_compression(level)?))
+    }
+
     pub fn with_bloom_filters(mut self, bloom_filters: BloomFilterConfig) -> Self {
         self.bloom_filters = bloom_filters;
         self
@@ -191,6 +203,22 @@ impl ParquetSinkOptions {
 
     pub fn with_column_no_dictionary(mut self, column_no_dictionary: Vec<String>) -> Self {
         self.column_no_dictionary = column_no_dictionary;
+        self
+    }
+
+    /// Apply dictionary configuration from CLI-style `ColumnDictionaryConfig` entries,
+    /// splitting them into always/analyze lists internally.
+    pub fn with_dictionary_configs(mut self, configs: &[ColumnDictionaryConfig]) -> Self {
+        let mut always = Vec::new();
+        let mut analyze = Vec::new();
+        for config in configs {
+            match config.mode {
+                DictionaryMode::Always => always.push(config.name.clone()),
+                DictionaryMode::Analyze => analyze.push(config.name.clone()),
+            }
+        }
+        self.column_dictionary_always = always;
+        self.column_dictionary_analyze = analyze;
         self
     }
 

--- a/tests/transform_cli_data_verification_test.rs
+++ b/tests/transform_cli_data_verification_test.rs
@@ -1175,3 +1175,138 @@ async fn test_parquet_row_order_preserved() {
         .value(0);
     assert_eq!(bad_names, 0, "found rows with incorrect names");
 }
+
+#[test]
+fn test_non_spillable_reserve_percentage_with_sort() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.arrow");
+
+    let batch = TestBatch::simple_with(&[5, 2, 8, 1, 3], &["e", "b", "h", "a", "c"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    cargo::cargo_bin_cmd!("silk-chiffon")
+        .args([
+            "transform",
+            "--from",
+            input.to_str().unwrap(),
+            "--to",
+            output.to_str().unwrap(),
+            "--sort-by",
+            "id",
+            "--non-spillable-reserve",
+            "10%",
+        ])
+        .assert()
+        .success();
+
+    let batches = TestFile::read_arrow(&output);
+    assert_eq!(TestExtract::i32_all(&batches, "id"), vec![1, 2, 3, 5, 8]);
+}
+
+#[test]
+fn test_non_spillable_reserve_fixed_bytes() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.parquet");
+
+    let batch = TestBatch::simple_with(&[3, 1, 2], &["c", "a", "b"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    cargo::cargo_bin_cmd!("silk-chiffon")
+        .args([
+            "transform",
+            "--from",
+            input.to_str().unwrap(),
+            "--to",
+            output.to_str().unwrap(),
+            "--non-spillable-reserve",
+            "50MB",
+        ])
+        .assert()
+        .success();
+
+    let batches = TestFile::read_parquet(&output);
+    assert_eq!(count_rows(&batches), 3);
+}
+
+#[test]
+fn test_memory_pool_top_consumers_flag() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.arrow");
+
+    let batch = TestBatch::simple_with(&[1, 2, 3], &["a", "b", "c"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    cargo::cargo_bin_cmd!("silk-chiffon")
+        .args([
+            "transform",
+            "--from",
+            input.to_str().unwrap(),
+            "--to",
+            output.to_str().unwrap(),
+            "--non-spillable-reserve",
+            "15",
+            "--memory-pool-top-consumers",
+            "0",
+        ])
+        .assert()
+        .success();
+
+    let batches = TestFile::read_arrow(&output);
+    assert_eq!(count_rows(&batches), 3);
+}
+
+#[test]
+fn test_nosort_evict_partitioned_output() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output_dir = temp_dir.path().join("output");
+    std::fs::create_dir_all(&output_dir).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("category", DataType::Utf8, false),
+        Field::new("value", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(StringArray::from(vec!["a", "b", "c", "a", "b"])),
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+        ],
+    )
+    .unwrap();
+    TestFile::write_arrow_batch(&input, &batch);
+
+    let template = output_dir.join("{{category}}.parquet");
+    cargo::cargo_bin_cmd!("silk-chiffon")
+        .args([
+            "transform",
+            "--from",
+            input.to_str().unwrap(),
+            "--to-many",
+            template.to_str().unwrap(),
+            "--by",
+            "category",
+            "--partition-strategy",
+            "nosort-evict",
+            "--max-open-partitions",
+            "2",
+            "--overwrite",
+        ])
+        .assert()
+        .success();
+
+    // with max_open=2 and 3 partitions, at least one eviction happens
+    // first files: a.parquet, b.parquet; then c triggers eviction
+    assert!(output_dir.join("a.parquet").exists());
+    assert!(output_dir.join("b.parquet").exists());
+    assert!(output_dir.join("c.parquet").exists());
+
+    // a reappears after eviction, so a_1.parquet should exist
+    assert!(
+        output_dir.join("a_1.parquet").exists(),
+        "evicted partition 'a' should reopen as a_1.parquet"
+    );
+}

--- a/tests/transform_integration_test.rs
+++ b/tests/transform_integration_test.rs
@@ -4,8 +4,8 @@ use camino::Utf8PathBuf;
 use silk_chiffon::{
     AllColumnsBloomFilterConfig, ArrowCompression, ArrowIPCFormat, ColumnDictionaryConfig,
     ColumnSpecificBloomFilterConfig, DataFormat, DictionaryMode, ListOutputsFormat,
-    ParquetCompression, ParquetStatistics, ParquetWriterVersion, PartitionStrategy, QueryDialect,
-    SortColumn, SortDirection, SortSpec,
+    ParquetCompression, ParquetStatistics, ParquetWriterVersion, PartitionStrategy,
+    PoolReserveSpec, QueryDialect, SortColumn, SortDirection, SortSpec,
     utils::test_data::{TestBatch, TestFile},
 };
 use std::path::Path;
@@ -3202,4 +3202,182 @@ async fn test_transform_sort_multi_file_with_spill_reservation() {
         })
         .collect();
     assert_eq!(ids, vec![1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn test_reserved_spill_pool_simple_transform() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.arrow");
+
+    let batch = TestBatch::simple_with(&[3, 1, 2], &["c", "a", "b"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    silk_chiffon::commands::transform::run(silk_chiffon::TransformCommand {
+        from: Some(input.to_string_lossy().to_string()),
+        to: Some(output.to_string_lossy().to_string()),
+        non_spillable_reserve: Some(PoolReserveSpec::Percent(10)),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.exists());
+    let batches = TestFile::read_arrow_auto(&output);
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
+}
+
+#[tokio::test]
+async fn test_reserved_spill_pool_with_sorting() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.arrow");
+
+    let batch = TestBatch::simple_with(&[3, 1, 2], &["c", "a", "b"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    silk_chiffon::commands::transform::run(silk_chiffon::TransformCommand {
+        from: Some(input.to_string_lossy().to_string()),
+        to: Some(output.to_string_lossy().to_string()),
+        non_spillable_reserve: Some(PoolReserveSpec::Percent(10)),
+        sort_by: Some(SortSpec {
+            columns: vec![SortColumn {
+                name: "id".to_string(),
+                direction: SortDirection::Ascending,
+            }],
+        }),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.exists());
+    let batches = TestFile::read_arrow_auto(&output);
+    let ids = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(ids.value(0), 1);
+    assert_eq!(ids.value(1), 2);
+    assert_eq!(ids.value(2), 3);
+}
+
+#[tokio::test]
+async fn test_reserved_spill_pool_with_fixed_reserve() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.parquet");
+
+    let batch = TestBatch::simple_with(&[5, 2, 4, 1, 3], &["e", "b", "d", "a", "c"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    silk_chiffon::commands::transform::run(silk_chiffon::TransformCommand {
+        from: Some(input.to_string_lossy().to_string()),
+        to: Some(output.to_string_lossy().to_string()),
+        output_format: Some(DataFormat::Parquet),
+        non_spillable_reserve: Some(PoolReserveSpec::Fixed(50 * 1024 * 1024)), // 50MB
+        sort_by: Some(SortSpec {
+            columns: vec![SortColumn {
+                name: "name".to_string(),
+                direction: SortDirection::Ascending,
+            }],
+        }),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.exists());
+    let batches = TestFile::read_parquet(&output);
+    let names = batches[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(names.value(0), "a");
+    assert_eq!(names.value(1), "b");
+    assert_eq!(names.value(2), "c");
+    assert_eq!(names.value(3), "d");
+    assert_eq!(names.value(4), "e");
+}
+
+#[tokio::test]
+async fn test_reserved_spill_pool_with_top_consumers() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output = temp_dir.path().join("output.arrow");
+
+    let batch = TestBatch::simple_with(&[1, 2, 3], &["a", "b", "c"]);
+    TestFile::write_arrow_batch(&input, &batch);
+
+    // exercise the top-consumers=0 (all) path alongside the reserved pool
+    silk_chiffon::commands::transform::run(silk_chiffon::TransformCommand {
+        from: Some(input.to_string_lossy().to_string()),
+        to: Some(output.to_string_lossy().to_string()),
+        non_spillable_reserve: Some(PoolReserveSpec::Percent(25)),
+        memory_pool_top_consumers: 0,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.exists());
+    let batches = TestFile::read_arrow_auto(&output);
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
+}
+
+#[tokio::test]
+async fn test_nosort_evict_partitioned_write() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("input.arrow");
+    let output_dir = temp_dir.path().join("output");
+    std::fs::create_dir_all(&output_dir).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("category", DataType::Utf8, false),
+        Field::new("value", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(StringArray::from(vec!["x", "y", "z", "x", "y"])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])),
+        ],
+    )
+    .unwrap();
+    TestFile::write_arrow_batch(&input, &batch);
+
+    let template = output_dir.join("{{category}}.parquet");
+    silk_chiffon::commands::transform::run(silk_chiffon::TransformCommand {
+        from: Some(input.to_string_lossy().to_string()),
+        to_many: Some(template.to_string_lossy().to_string()),
+        by: Some("category".to_string()),
+        partition_strategy: PartitionStrategy::NosortEvict,
+        max_open_partitions: Some(2),
+        overwrite: true,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    // with max_open=2, x and y open first; z evicts x; then x reopens as x_1
+    assert!(output_dir.join("x.parquet").exists());
+    assert!(output_dir.join("y.parquet").exists());
+    assert!(output_dir.join("z.parquet").exists());
+    assert!(
+        output_dir.join("x_1.parquet").exists(),
+        "evicted partition should reopen with _1 suffix"
+    );
+
+    // verify data correctness: all 5 rows present across files
+    let mut total_rows = 0;
+    for entry in std::fs::read_dir(&output_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|e| e == "parquet") {
+            let batches = TestFile::read_parquet(&path);
+            total_rows += batches.iter().map(|b| b.num_rows()).sum::<usize>();
+        }
+    }
+    assert_eq!(total_rows, 5);
 }


### PR DESCRIPTION
# WTF
- New memory pool (`ReservedSpillPool`) that reserves capacity for non-spillable consumers so sort merge phases don't get starved. All pools now wrapped in `TrackConsumersPool` for better OOM errors.
- New `nosort-evict` partition strategy with LRU eviction for high-cardinality partitioned writes. Works like DuckDB and DataFusion partitioning, where multiple files can be written.
- Refactored sink factory from 30 positional args to pre-built option structs.
- Fix `count_distinct` return type handling in `analysis.rs`.

## New flags

- `--non-spillable-reserve` - reserve memory for non-spillable ops (10% or 50MB)
- `--memory-pool-top-consumers` - how many consumers to show in OOM errors (default 10)
- `--partition-strategy=nosort-evict` - LRU-evicting partition writer, like DuckDB and DataFusion
- `--max-open-partitions` - cap on open partition writers (default 100, nosort-evict only)
