### PR TITLE
Remove version from parquet created-by field

### DIFF
--- a/src/sinks/arrow.rs
+++ b/src/sinks/arrow.rs
@@ -443,6 +443,28 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_default_file_metadata_is_empty() {
+            let temp_dir = tempdir().unwrap();
+            let output_path = temp_dir.path().join("output.arrow");
+
+            let schema = test_data::simple_schema();
+            let batch =
+                test_data::create_batch_with_ids_and_names(&schema, &[1, 2, 3], &["a", "b", "c"]);
+
+            let mut sink =
+                ArrowSink::create(output_path.clone(), &schema, ArrowSinkOptions::new()).unwrap();
+
+            sink.write_batch(batch).await.unwrap();
+            sink.finish().await.unwrap();
+
+            let file = std::fs::File::open(&output_path).unwrap();
+            let reader = arrow::ipc::reader::FileReader::try_new_buffered(file, None).unwrap();
+
+            assert!(reader.custom_metadata().is_empty());
+            assert!(reader.schema().metadata().is_empty());
+        }
+
+        #[tokio::test]
         async fn test_sink_empty_batches() {
             let temp_dir = tempdir().unwrap();
             let output_path = temp_dir.path().join("output.arrow");

--- a/src/sinks/parquet/mod.rs
+++ b/src/sinks/parquet/mod.rs
@@ -12,6 +12,7 @@ pub const DEFAULT_MAX_ROW_GROUP_SIZE: usize = 1_048_576;
 pub const DEFAULT_WRITE_BATCH_SIZE: usize = 8192;
 pub const DEFAULT_DATA_PAGE_SIZE_LIMIT: usize = 100 * 1024 * 1024; // 100MiB (DuckDB MAX_UNCOMPRESSED_PAGE_SIZE)
 pub const DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT: usize = 1024 * 1024 * 1024; // 1GiB (DuckDB MAX_UNCOMPRESSED_DICT_PAGE_SIZE)
+const PARQUET_CREATED_BY: &str = "silk-chiffon";
 
 use parquet::{
     basic::Compression,
@@ -361,7 +362,7 @@ impl ParquetSink {
         runtimes: Arc<ParquetRuntimes>,
     ) -> Result<Self> {
         let mut writer_builder = WriterProperties::builder()
-            .set_created_by(format!("silk-chiffon v{}", env!("SILK_CHIFFON_VERSION")))
+            .set_created_by(PARQUET_CREATED_BY.to_string())
             .set_max_row_group_row_count(Some(options.max_row_group_size))
             .set_compression(options.compression)
             .set_writer_version(options.writer_version.into())
@@ -838,6 +839,36 @@ mod tests {
 
             let file = read_entire_parquet_file(&output_path).unwrap();
             assert_eq!(file.row_groups.len(), 1);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_default_file_metadata_is_stable() {
+            let temp_dir = tempdir().unwrap();
+            let output_path = temp_dir.path().join("output.parquet");
+
+            let schema = test_data::simple_schema();
+            let batch =
+                test_data::create_batch_with_ids_and_names(&schema, &[1, 2, 3], &["a", "b", "c"]);
+
+            let mut sink = ParquetSink::create(
+                output_path.clone(),
+                &schema,
+                &ParquetSinkOptions::new(),
+                test_runtimes(),
+            )
+            .unwrap();
+
+            sink.write_batch(batch).await.unwrap();
+            sink.finish().await.unwrap();
+
+            let file = parquet::file::reader::SerializedFileReader::try_from(
+                std::fs::File::open(&output_path).unwrap(),
+            )
+            .unwrap();
+            let file_metadata = file.metadata().file_metadata();
+
+            assert_eq!(file_metadata.created_by(), Some(PARQUET_CREATED_BY));
+            assert!(file_metadata.key_value_metadata().is_none());
         }
 
         #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
# WTF

Remove the version from the parquet created-by field so that our generated parquet files are less likely to change when silk is updated.

# Checklist

- [x] Tested
- [x] Formatted
- [x] Linted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Parquet file `created_by` metadata from a versioned string to a constant, which will alter generated file headers and could affect consumers or snapshot-based tests expecting the previous value.
> 
> **Overview**
> **Stabilizes output metadata for Parquet and Arrow sinks.** Parquet files now write a constant `created_by` value (`"silk-chiffon"`) instead of embedding the build version, reducing file churn across releases.
> 
> Adds regression tests to ensure default metadata stays empty/stable: Arrow file writes include no schema/custom metadata by default, and Parquet files have the expected `created_by` value with no default key-value metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8efe287159610fd60009ebc799c8a1034365c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->